### PR TITLE
Add stop-and-copy script for database migration

### DIFF
--- a/copy-from-postgres10-to-postgres14.yaml
+++ b/copy-from-postgres10-to-postgres14.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-copy-script
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -e
+
+    echo "${DB_HOST_SOURCE}:5432:${DB_NAME_SOURCE}:${DB_USER_SOURCE}:${DB_PASS_SOURCE}" > ~/.pgpass
+    echo "${DB_HOST_TARGET}:5432:${DB_NAME_TARGET}:${DB_USER_TARGET}:${DB_PASS_TARGET}" >> ~/.pgpass
+    chmod 0600 ~/.pgpass
+
+    set -x
+    pg_dump --host="$DB_HOST_SOURCE" --username="$DB_USER_SOURCE" --format=custom --no-privileges --verbose --file=/tmp/db.dump "$DB_NAME_SOURCE"
+    pg_restore --host="$DB_HOST_TARGET" --username="$DB_USER_TARGET" --clean --no-owner --verbose --dbname="$DB_NAME_TARGET" /tmp/db.dump
+
+    rm -v /tmp/db.dump ~/.pgpass
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: db-copy-once
+spec:
+  ttlSecondsAfterFinished: 1800
+  template:
+    spec:
+      securityContext:
+        runAsUser: 999
+      restartPolicy: "Never"
+      volumes:
+      - name: db-copy-volume
+        configMap:
+          name: db-copy-script
+          defaultMode: 0755
+      containers:
+      - name: dbcopy
+        image: "postgres:14"
+        command:
+          - /bin/entrypoint.sh
+        volumeMounts:
+          - name: db-copy-volume
+            mountPath: /bin/entrypoint.sh
+            readOnly: true
+            subPath: entrypoint.sh
+        env:
+          - name: DB_NAME_SOURCE
+            valueFrom:
+              secretKeyRef:
+                name: postgres
+                key: database_name
+          - name: DB_USER_SOURCE
+            valueFrom:
+              secretKeyRef:
+                name: postgres
+                key: database_username
+          - name: DB_PASS_SOURCE
+            valueFrom:
+              secretKeyRef:
+                name: postgres
+                key: database_password
+          - name: DB_HOST_SOURCE
+            valueFrom:
+              secretKeyRef:
+                name: postgres
+                key: rds_instance_address
+          - name: DB_NAME_TARGET
+            valueFrom:
+              secretKeyRef:
+                name: postgres14
+                key: database_name
+          - name: DB_USER_TARGET
+            valueFrom:
+              secretKeyRef:
+                name: postgres14
+                key: database_username
+          - name: DB_PASS_TARGET
+            valueFrom:
+              secretKeyRef:
+                name: postgres14
+                key: database_password
+          - name: DB_HOST_TARGET
+            valueFrom:
+              secretKeyRef:
+                name: postgres14
+                key: rds_instance_address

--- a/copy_dev_postgres_to_v14.sh
+++ b/copy_dev_postgres_to_v14.sh
@@ -1,0 +1,61 @@
+#!/bin/sh -e
+target_namespace="hmpps-interventions-dev"
+
+echo "Going to stop and migrate $target_namespace"
+echo "Please verify             ^^^^^^^^^^^^^^^^^^^^^^^^^^^ and abort if necessary."
+sleep 2
+
+
+echo
+echo "✨ Stopping UI"
+kubectl scale \
+  --namespace="$target_namespace" \
+  --replicas=0 \
+  --timeout=5m \
+  deployment/hmpps-interventions-ui
+
+
+echo
+echo "✨ Waiting for all pods to fully shut down"
+kubectl wait --for=delete --timeout=-1s \
+  --namespace="$target_namespace" \
+  --selector=release=hmpps-interventions-ui \
+  pod
+
+
+echo
+echo "✨ Stopping API/jobs"
+kubectl scale \
+  --namespace="$target_namespace" \
+  --replicas=0 \
+  --timeout=5m \
+  --selector=app.kubernetes.io/name=hmpps-interventions-service \
+  deployment
+
+
+echo
+echo "✨ Waiting for all pods to fully shut down"
+kubectl wait --for=delete --timeout=-1s \
+  --namespace="$target_namespace" \
+  --selector=release=hmpps-interventions-service \
+  pod
+
+
+echo
+echo "✨ Starting copy job"
+
+kubectl apply \
+  --namespace="$target_namespace" \
+  --filename=./copy-from-postgres10-to-postgres14.yaml
+
+echo
+echo "✨ Waiting for copy job to finish"
+
+kubectl wait --for=condition=Complete --timeout=-1s \
+  --namespace="$target_namespace" \
+  job/db-copy-once
+
+
+echo
+echo "⏭  Done: deploy the postgres14 config change"
+echo "🔃 To retry, delete job/db-copy-once and run this script again"


### PR DESCRIPTION
We are migrating to PostgreSQL 14 by setting up a completely new instance.

To facilitate the migration, we need to:

1. Gracefully stop serving traffic
2. Ensure everything has stopped
3. Copy the contents of the PostgreSQL 10 database to PostgreSQL 14
4. Re-deploy the application with the new configuration pointing to the new database

This commit adds a script doing the first 3 points on dev.